### PR TITLE
fix: edge cases

### DIFF
--- a/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/BaseClasses_A_BaseClass.g.cs
+++ b/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/BaseClasses_A_BaseClass.g.cs
@@ -30,7 +30,7 @@ partial class BaseClass : Chickensoft.Introspection.IIntrospective {
           OpenType: typeof(string),
           ClosedType: typeof(string),
           Arguments: System.Array.Empty<GenericType>(),
-          GenericTypeGetter: receiver => receiver.Receive<string>(),
+          GenericTypeGetter: static receiver => receiver.Receive<string>(),
           GenericTypeGetter2: default
         ),
         Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {

--- a/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/TestCases_SetOnlyPropertyE303C8557E.g.cs
+++ b/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/TestCases_SetOnlyPropertyE303C8557E.g.cs
@@ -28,7 +28,7 @@ partial record class SetOnlyProperty : Chickensoft.Introspection.IIntrospective 
           OpenType: typeof(string),
           ClosedType: typeof(string),
           Arguments: System.Array.Empty<GenericType>(),
-          GenericTypeGetter: receiver => receiver.Receive<string>(),
+          GenericTypeGetter: static receiver => receiver.Receive<string>(),
           GenericTypeGetter2: default
         ),
         Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {

--- a/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/Tests_TestCases_BaseModel6634CD33B5.g.cs
+++ b/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/Tests_TestCases_BaseModel6634CD33B5.g.cs
@@ -31,7 +31,7 @@ partial class BaseModel : Chickensoft.Introspection.IIntrospective {
           OpenType: typeof(string),
           ClosedType: typeof(string),
           Arguments: System.Array.Empty<GenericType>(),
-          GenericTypeGetter: receiver => receiver.Receive<string>(),
+          GenericTypeGetter: static receiver => receiver.Receive<string>(),
           GenericTypeGetter2: default
         ),
         Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {

--- a/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/_MyContainerClass_MyModel67E837FC39.g.cs
+++ b/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/_MyContainerClass_MyModel67E837FC39.g.cs
@@ -32,7 +32,7 @@ partial class MyContainerClass {
             OpenType: typeof(int),
             ClosedType: typeof(int),
             Arguments: System.Array.Empty<GenericType>(),
-            GenericTypeGetter: receiver => receiver.Receive<int>(),
+            GenericTypeGetter: static receiver => receiver.Receive<int>(),
             GenericTypeGetter2: default
           ),
           Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {
@@ -52,7 +52,7 @@ partial class MyContainerClass {
             OpenType: typeof(string),
             ClosedType: typeof(string),
             Arguments: System.Array.Empty<GenericType>(),
-            GenericTypeGetter: receiver => receiver.Receive<string>(),
+            GenericTypeGetter: static receiver => receiver.Receive<string>(),
             GenericTypeGetter2: default
           ),
           Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {

--- a/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/er2_DeeplyNestedBaseClassAC795ED913.g.cs
+++ b/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/er2_DeeplyNestedBaseClassAC795ED913.g.cs
@@ -32,7 +32,7 @@ partial class Container {
               OpenType: typeof(string),
               ClosedType: typeof(string),
               Arguments: System.Array.Empty<GenericType>(),
-              GenericTypeGetter: receiver => receiver.Receive<string>(),
+              GenericTypeGetter: static receiver => receiver.Receive<string>(),
               GenericTypeGetter2: default
             ),
             Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {

--- a/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/her_A_B_C_D_SomeBaseClassECA01F390E.g.cs
+++ b/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/her_A_B_C_D_SomeBaseClassECA01F390E.g.cs
@@ -34,7 +34,7 @@ partial class A {
                   OpenType: typeof(string),
                   ClosedType: typeof(string),
                   Arguments: System.Array.Empty<GenericType>(),
-                  GenericTypeGetter: receiver => receiver.Receive<string>(),
+                  GenericTypeGetter: static receiver => receiver.Receive<string>(),
                   GenericTypeGetter2: default
                 ),
                 Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {

--- a/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/or_Tests_TestCases_MyType1CDCCD6086.g.cs
+++ b/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/or_Tests_TestCases_MyType1CDCCD6086.g.cs
@@ -35,7 +35,7 @@ partial class MyType : Chickensoft.Introspection.IIntrospective, Chickensoft.Int
           OpenType: typeof(string),
           ClosedType: typeof(string),
           Arguments: System.Array.Empty<GenericType>(),
-          GenericTypeGetter: receiver => receiver.Receive<string>(),
+          GenericTypeGetter: static receiver => receiver.Receive<string>(),
           GenericTypeGetter2: default
         ),
         Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {
@@ -59,7 +59,7 @@ partial class MyType : Chickensoft.Introspection.IIntrospective, Chickensoft.Int
           OpenType: typeof(int),
           ClosedType: typeof(int),
           Arguments: System.Array.Empty<GenericType>(),
-          GenericTypeGetter: receiver => receiver.Receive<int>(),
+          GenericTypeGetter: static receiver => receiver.Receive<int>(),
           GenericTypeGetter2: default
         ),
         Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {
@@ -80,11 +80,11 @@ partial class MyType : Chickensoft.Introspection.IIntrospective, Chickensoft.Int
                 OpenType: typeof(float),
                 ClosedType: typeof(float),
                 Arguments: System.Array.Empty<GenericType>(),
-                GenericTypeGetter: receiver => receiver.Receive<float>(),
+                GenericTypeGetter: static receiver => receiver.Receive<float>(),
                 GenericTypeGetter2: default
               )
           },
-          GenericTypeGetter: receiver => receiver.Receive<Nullable<float>>(),
+          GenericTypeGetter: static receiver => receiver.Receive<Nullable<float>>(),
           GenericTypeGetter2: default
         ),
         Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {
@@ -104,7 +104,7 @@ partial class MyType : Chickensoft.Introspection.IIntrospective, Chickensoft.Int
           OpenType: typeof(int),
           ClosedType: typeof(int),
           Arguments: System.Array.Empty<GenericType>(),
-          GenericTypeGetter: receiver => receiver.Receive<int>(),
+          GenericTypeGetter: static receiver => receiver.Receive<int>(),
           GenericTypeGetter2: default
         ),
         Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {

--- a/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/s_AttributesWithNamedArgs21E465F742.g.cs
+++ b/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/s_AttributesWithNamedArgs21E465F742.g.cs
@@ -31,7 +31,7 @@ partial class AttributesWithNamedArgs : Chickensoft.Introspection.IIntrospective
           OpenType: typeof(string),
           ClosedType: typeof(string),
           Arguments: System.Array.Empty<GenericType>(),
-          GenericTypeGetter: receiver => receiver.Receive<string>(),
+          GenericTypeGetter: static receiver => receiver.Receive<string>(),
           GenericTypeGetter2: default
         ),
         Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {

--- a/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/s_TestCases_InitArgsModel651DDFA4A7.g.cs
+++ b/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/s_TestCases_InitArgsModel651DDFA4A7.g.cs
@@ -31,7 +31,7 @@ partial class InitArgsModel : Chickensoft.Introspection.IIntrospective, Chickens
           OpenType: typeof(string),
           ClosedType: typeof(string),
           Arguments: System.Array.Empty<GenericType>(),
-          GenericTypeGetter: receiver => receiver.Receive<string>(),
+          GenericTypeGetter: static receiver => receiver.Receive<string>(),
           GenericTypeGetter2: default
         ),
         Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {
@@ -51,7 +51,7 @@ partial class InitArgsModel : Chickensoft.Introspection.IIntrospective, Chickens
           OpenType: typeof(int),
           ClosedType: typeof(int),
           Arguments: System.Array.Empty<GenericType>(),
-          GenericTypeGetter: receiver => receiver.Receive<int>(),
+          GenericTypeGetter: static receiver => receiver.Receive<int>(),
           GenericTypeGetter2: default
         ),
         Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {
@@ -71,7 +71,7 @@ partial class InitArgsModel : Chickensoft.Introspection.IIntrospective, Chickens
           OpenType: typeof(string),
           ClosedType: typeof(string),
           Arguments: System.Array.Empty<GenericType>(),
-          GenericTypeGetter: receiver => receiver.Receive<string>(),
+          GenericTypeGetter: static receiver => receiver.Receive<string>(),
           GenericTypeGetter2: default
         ),
         Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {
@@ -91,7 +91,7 @@ partial class InitArgsModel : Chickensoft.Introspection.IIntrospective, Chickens
           OpenType: typeof(InitArgsEnum),
           ClosedType: typeof(InitArgsEnum),
           Arguments: System.Array.Empty<GenericType>(),
-          GenericTypeGetter: receiver => receiver.Receive<InitArgsEnum>(),
+          GenericTypeGetter: static receiver => receiver.Receive<InitArgsEnum>(),
           GenericTypeGetter2: default
         ),
         Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {
@@ -111,7 +111,7 @@ partial class InitArgsModel : Chickensoft.Introspection.IIntrospective, Chickens
           OpenType: typeof(InitArgsEnum),
           ClosedType: typeof(InitArgsEnum),
           Arguments: System.Array.Empty<GenericType>(),
-          GenericTypeGetter: receiver => receiver.Receive<InitArgsEnum>(),
+          GenericTypeGetter: static receiver => receiver.Receive<InitArgsEnum>(),
           GenericTypeGetter2: default
         ),
         Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {
@@ -131,7 +131,7 @@ partial class InitArgsModel : Chickensoft.Introspection.IIntrospective, Chickens
           OpenType: typeof(string),
           ClosedType: typeof(string),
           Arguments: System.Array.Empty<GenericType>(),
-          GenericTypeGetter: receiver => receiver.Receive<string>(),
+          GenericTypeGetter: static receiver => receiver.Receive<string>(),
           GenericTypeGetter2: default
         ),
         Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {

--- a/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/s_TestCases_PropertyModel4D221791B1.g.cs
+++ b/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/s_TestCases_PropertyModel4D221791B1.g.cs
@@ -28,7 +28,7 @@ partial record class PropertyModel : Chickensoft.Introspection.IIntrospective {
           OpenType: typeof(string),
           ClosedType: typeof(string),
           Arguments: System.Array.Empty<GenericType>(),
-          GenericTypeGetter: receiver => receiver.Receive<string>(),
+          GenericTypeGetter: static receiver => receiver.Receive<string>(),
           GenericTypeGetter2: default
         ),
         Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {

--- a/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/sts_TestCases_Collections23D60571D5.g.cs
+++ b/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/sts_TestCases_Collections23D60571D5.g.cs
@@ -39,11 +39,11 @@ partial class Collections : Chickensoft.Introspection.IIntrospective {
                       OpenType: typeof(string),
                       ClosedType: typeof(string),
                       Arguments: System.Array.Empty<GenericType>(),
-                      GenericTypeGetter: receiver => receiver.Receive<string>(),
+                      GenericTypeGetter: static receiver => receiver.Receive<string>(),
                       GenericTypeGetter2: default
                     )
                 },
-                GenericTypeGetter: receiver => receiver.Receive<List<string>>(),
+                GenericTypeGetter: static receiver => receiver.Receive<List<string>>(),
                 GenericTypeGetter2: default
               ), 
               new GenericType(
@@ -58,20 +58,20 @@ partial class Collections : Chickensoft.Introspection.IIntrospective {
                             OpenType: typeof(int),
                             ClosedType: typeof(int),
                             Arguments: System.Array.Empty<GenericType>(),
-                            GenericTypeGetter: receiver => receiver.Receive<int>(),
+                            GenericTypeGetter: static receiver => receiver.Receive<int>(),
                             GenericTypeGetter2: default
                           )
                       },
-                      GenericTypeGetter: receiver => receiver.Receive<List<int>>(),
+                      GenericTypeGetter: static receiver => receiver.Receive<List<int>>(),
                       GenericTypeGetter2: default
                     )
                 },
-                GenericTypeGetter: receiver => receiver.Receive<List<List<int>>>(),
+                GenericTypeGetter: static receiver => receiver.Receive<List<List<int>>>(),
                 GenericTypeGetter2: default
               )
           },
-          GenericTypeGetter: receiver => receiver.Receive<Dictionary<List<string>, List<List<int>>>>(),
-          GenericTypeGetter2: receiver => receiver.Receive<List<string>, List<List<int>>>()
+          GenericTypeGetter: static receiver => receiver.Receive<Dictionary<List<string>, List<List<int>>>>(),
+          GenericTypeGetter2: static receiver => receiver.Receive<List<string>, List<List<int>>>()
         ),
         Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {
           [typeof(TagAttribute)] = new System.Attribute[] {

--- a/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/ts_TestCases_DerivedModel2583598D69.g.cs
+++ b/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/ts_TestCases_DerivedModel2583598D69.g.cs
@@ -31,7 +31,7 @@ partial class DerivedModel : Chickensoft.Introspection.IIntrospective {
           OpenType: typeof(int),
           ClosedType: typeof(int),
           Arguments: System.Array.Empty<GenericType>(),
-          GenericTypeGetter: receiver => receiver.Receive<int>(),
+          GenericTypeGetter: static receiver => receiver.Receive<int>(),
           GenericTypeGetter2: default
         ),
         Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {

--- a/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/ts_TestCases_PartialModelED2F9C08D8.g.cs
+++ b/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/ts_TestCases_PartialModelED2F9C08D8.g.cs
@@ -31,7 +31,7 @@ partial class PartialModel : Chickensoft.Introspection.IIntrospective, Chickenso
           OpenType: typeof(int),
           ClosedType: typeof(int),
           Arguments: System.Array.Empty<GenericType>(),
-          GenericTypeGetter: receiver => receiver.Receive<int>(),
+          GenericTypeGetter: static receiver => receiver.Receive<int>(),
           GenericTypeGetter2: default
         ),
         Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {
@@ -51,7 +51,7 @@ partial class PartialModel : Chickensoft.Introspection.IIntrospective, Chickenso
           OpenType: typeof(string),
           ClosedType: typeof(string),
           Arguments: System.Array.Empty<GenericType>(),
-          GenericTypeGetter: receiver => receiver.Receive<string>(),
+          GenericTypeGetter: static receiver => receiver.Receive<string>(),
           GenericTypeGetter2: default
         ),
         Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {

--- a/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/wo_IThree_Four_NestedType7FDE758058.g.cs
+++ b/Chickensoft.Introspection.Generator.Tests/.generated/Chickensoft.Introspection.Generator/Chickensoft.Introspection.Generator.TypeGenerator/wo_IThree_Four_NestedType7FDE758058.g.cs
@@ -39,7 +39,7 @@ static partial class One {
                   OpenType: typeof(string),
                   ClosedType: typeof(string),
                   Arguments: System.Array.Empty<GenericType>(),
-                  GenericTypeGetter: receiver => receiver.Receive<string>(),
+                  GenericTypeGetter: static receiver => receiver.Receive<string>(),
                   GenericTypeGetter2: default
                 ),
                 Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {
@@ -63,7 +63,7 @@ static partial class One {
                   OpenType: typeof(float),
                   ClosedType: typeof(float),
                   Arguments: System.Array.Empty<GenericType>(),
-                  GenericTypeGetter: receiver => receiver.Receive<float>(),
+                  GenericTypeGetter: static receiver => receiver.Receive<float>(),
                   GenericTypeGetter2: default
                 ),
                 Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {
@@ -83,7 +83,7 @@ static partial class One {
                   OpenType: typeof(int),
                   ClosedType: typeof(int),
                   Arguments: System.Array.Empty<GenericType>(),
-                  GenericTypeGetter: receiver => receiver.Receive<int>(),
+                  GenericTypeGetter: static receiver => receiver.Receive<int>(),
                   GenericTypeGetter2: default
                 ),
                 Attributes: new System.Collections.Generic.Dictionary<System.Type, System.Attribute[]>() {

--- a/Chickensoft.Introspection.Generator.Tests/test_cases/UsingAmbiguity.cs
+++ b/Chickensoft.Introspection.Generator.Tests/test_cases/UsingAmbiguity.cs
@@ -1,0 +1,14 @@
+namespace Chickensoft.Introspection.Generator.Tests.TestCases;
+
+using System.IO;
+using Result = (int, string);
+
+public static class UsingAmbiguity {
+  // make sure tuple aliases don't interfere with using imports
+  public static Result DoSomething() => (1, "Hello");
+
+  public static void DoSomethingWithADisposable() {
+    // make sure using statements don't interfere with using imports
+    using var stream = new MemoryStream();
+  }
+}

--- a/Chickensoft.Introspection.Generator/src/models/DeclaredTypeKind.cs
+++ b/Chickensoft.Introspection.Generator/src/models/DeclaredTypeKind.cs
@@ -4,5 +4,6 @@ public enum DeclaredTypeKind {
   StaticClass,
   AbstractType,
   ConcreteType,
-  Interface
+  Interface,
+  Error
 }

--- a/Chickensoft.Introspection/src/types/IIntrospective.cs
+++ b/Chickensoft.Introspection/src/types/IIntrospective.cs
@@ -30,8 +30,8 @@ public interface IIntrospective {
   /// Invokes the handler of each mixin that is applied to the type.
   /// </summary>
   public void InvokeMixins() {
-    foreach (var mixin in Metatype.Mixins) {
-      Metatype.MixinHandlers[mixin](this);
+    for (var i = 0; i < Metatype.Mixins.Count; i++) {
+      Metatype.MixinHandlers[Metatype.Mixins[i]](this);
     }
   }
 


### PR DESCRIPTION
addresses edge cases (eliminate enumerator boxing, errors when merging partial declared type kinds depending on compilation order, and using alias statements (unrelated to imports)

fixes #9 
fixes #8 