### PR TITLE
chore: fix run-tests action on forks

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,6 @@ jobs:
       - name: 🧾 Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_BASIC }}
           lfs: true
           submodules: "recursive"
 


### PR DESCRIPTION
Same as chickensoft-games/GodotPackage#122. Including a GitHub token causes the Tests action to fail at the checkout step in forks that don't have a GitHub token configured. Removing the token allows forks to run the Tests action.